### PR TITLE
Updated def clean() in util.py

### DIFF
--- a/util.py
+++ b/util.py
@@ -103,8 +103,18 @@ def select_note_fields_del(note_id):
 def clean(s):
     # remove HTML
     s = stripHTML(s)
-    # remove everyhing in brackets
-    s = re.sub(r'[\[\(\{][^\]\)\}]*[\]\)\}]', '', s)
+    # remove everything in any kind of brackets
+    # won't work well with nested brackets, but I doubt it'll totally break anything
+    # and for these purposes nested brackets probably are rare
+    s = re.sub(r'\([^)]*\)', '', s)
+    s = re.sub(r'\[[^)]*\]', '', s)
+    s = re.sub(r'{[^)]*}', '', s)
+    s = re.sub(r'「[^)]*」', '', s)
+    s = re.sub(r'（[^)]*）', '', s)
+    s = re.sub(r'｛[^)]*｝', '', s)
+    # remove all non-Japanese characters
+    # "一-鿼" is kanji, "぀-ゟ" is hiragana, and "゠-ヿ" is katakana
+    s = re.sub(r'[^一-鿼぀-ゟ゠-ヿ]', "", s)
     return s.strip()
 
 def get_acc_patt(expr_field, reading_field, dicts):
@@ -220,6 +230,6 @@ def is_katakana(s):
     return num_ktkn / max(1, len(s)) > .5
 
 def clean_orth(orth):
-    orth = re.sub('[()△×･〈〉{}]', '', orth)  # 
+    orth = re.sub('[()△×･〈〉{}]', '', orth)  #
     orth = orth.replace('…', '〜')  # change depending on what you use
     return orth


### PR DESCRIPTION
Thanks for the really great plug-in. I wanted to help improve it since I noticed it doesn't recognize some cards.
First of all, I changed it so that it can recognize six different kinds of brackets instead of just one. This way cards like きれい（な） will be changed to きれい.
Also, based on the assumption that your accent dictionary doesn't use non-Japanese characters, the updated version should remove them.