### PR TITLE
Let user_pitchdb.csv load multiple readings

### DIFF
--- a/util.py
+++ b/util.py
@@ -93,7 +93,10 @@ def get_user_accent_dict(path):
     with open(path, encoding='utf8') as f:
         for line in f:
             orth, hira, patt = line.strip().split('\t')
-            acc_dict[orth] = [(hira, patt)]
+            if orth in acc_dict:
+                acc_dict[orth].append((hira, patt))
+            else:
+                acc_dict[orth] = [(hira, patt)]
     return acc_dict
 
 def get_note_type_ids(deck_id):


### PR DESCRIPTION
I assume this is a a bug. Right now at most one reading per word can be added from `user_pitchdb.csv` because `acc_dict[orth]` is always directly overwritten as a length-1 list in `get_user_accent_dict()` and never actually appended to. This short commit lets multiple readings be loaded.