### PR TITLE
Add type hints and clean up code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[project]
+requires-python = ">=3.9"

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-pysrc     := __init__.py _version.py _constants.py draw_pitch.py util.py
+pysrc     := __init__.py _version.py _constants.py draw_pitch.py types.py util.py
 distfiles := $(pysrc) icon_auto.png icon_manual.png ../LICENSE manifest.json \
              NOTE user_pitchdb.csv wadoku_pitchdb.csv
 version   := `grep -Po "(?<=__version__ = ')\d+\.\d+\.\d+(?=')" _version.py`

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -15,6 +15,7 @@ __license__ = "MIT"
 import json
 import os
 import re
+import sys
 from aqt import mw, gui_hooks
 from aqt.utils import showInfo, showText, getText
 from aqt.qt import QMenu
@@ -371,6 +372,18 @@ pa_menu_add_user = pa_menu.addAction("manually add/edit/remove")
 pa_menu_remove_user = pa_menu.addAction("remove all manually set")
 pa_menu_custom_db_path = pa_menu.addAction("show custom DB path")
 pa_menu_about = pa_menu.addAction("about")
+if not (
+    pa_menu
+    and pa_menu_add
+    and pa_menu_remove
+    and pa_menu_add_user
+    and pa_menu_remove_user
+    and pa_menu_custom_db_path
+    and pa_menu_about
+):
+    # exit if any of the above could not be created
+    sys.exit(1)
+
 # add triggers
 pa_menu_add.triggered.connect(add_pitch_dialog)
 pa_menu_remove.triggered.connect(remove_pitch_dialog)
@@ -378,8 +391,10 @@ pa_menu_add_user.triggered.connect(add_user_pitch_dialog)
 pa_menu_remove_user.triggered.connect(remove_user_pitch_dialog)
 pa_menu_custom_db_path.triggered.connect(show_custom_db_path_dialog)
 pa_menu_about.triggered.connect(about_dialog)
+
 # and add it to the tools menu
 mw.form.menuTools.addMenu(pa_menu)
+
 # add editor button
 gui_hooks.editor_did_init_buttons.append(add_set_pitch_buttons)
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -163,7 +163,7 @@ def show_custom_db_path_dialog():
 
     custom_db_text = (
         "You can extend and overwrite pitch accent patterns using the"
-        ' file "{}". The file has to be three columns (expression,'
+        " file '{}'. The file has to be three columns (expression,"
         " reading, pitch accent pattern) separated by TAB characters."
     ).format(user_pitch_csv_path)
     showInfo(custom_db_text, title="Custom DB path")

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,16 +1,16 @@
-""" Anki plugin to add pitch accent indicators to cards.
+"""Anki plugin to add pitch accent indicators to cards.
 
-    This plugin makes use of data from Wadoku by Ulrich Apel.
-    (See file wadoku_parse.py for more details.)
-    Wadoku license information is available on the web:
+This plugin makes use of data from Wadoku by Ulrich Apel.
+(See file wadoku_parse.py for more details.)
+Wadoku license information is available on the web:
 
-    http://www.wadoku.de/wiki/display/WAD/Wörterbuch+Lizenz
-    http://www.wadoku.de/wiki/display/WAD/%28Vorschlag%29+Neue+Wadoku-Daten+Lizenz
+http://www.wadoku.de/wiki/display/WAD/Wörterbuch+Lizenz
+http://www.wadoku.de/wiki/display/WAD/%28Vorschlag%29+Neue+Wadoku-Daten+Lizenz
 """
 
-__author__ = 'Tarek Saier'
-__credits__ = ['kclisp', 'Peter Maxwell']
-__license__ = 'MIT'
+__author__ = "Tarek Saier"
+__credits__ = ["kclisp", "Peter Maxwell"]
+__license__ = "MIT"
 
 import json
 import os
@@ -20,75 +20,81 @@ from aqt.utils import showInfo, showText, getText
 from aqt.qt import QMenu
 from ._version import __version__
 from ._constants import re_all_hira_patt
-from .util import add_pitch, remove_pitch, get_accent_dict, get_note_type_ids,\
-                  get_note_ids, get_user_accent_dict, select_deck_id,\
-                  select_note_type_id, select_note_fields_add,\
-                  select_note_fields_del, get_plugin_dir_path,\
-                  get_acc_patt, clean_japanese_from_note_field
+from .util import (
+    add_pitch,
+    remove_pitch,
+    get_accent_dict,
+    get_note_type_ids,
+    get_note_ids,
+    get_user_accent_dict,
+    select_deck_id,
+    select_note_type_id,
+    select_note_fields_add,
+    select_note_fields_del,
+    get_plugin_dir_path,
+    get_acc_patt,
+    clean_japanese_from_note_field,
+)
 from .draw_pitch import pitch_svg
 
 
 def about_dialog():
-    """ Popup displaying information about the add-on.
-    """
+    """Popup displaying information about the add-on."""
 
-    gh_link = 'https://github.com/IllDepence/anki_add_pitch_plugin'
-    aw_link = 'https://ankiweb.net/shared/info/148002038'
-    license_link = gh_link + '/blob/master/LICENSE'
+    gh_link = "https://github.com/IllDepence/anki_add_pitch_plugin"
+    aw_link = "https://ankiweb.net/shared/info/148002038"
+    license_link = gh_link + "/blob/master/LICENSE"
 
     info_text = (
-        '<center>'
-        '<h3>Japanese Pitch Accent</h3>'
-        '<p><b>Version</b><br>{version}</p>'
-        '<p><b>License</b><br>'
+        "<center>"
+        "<h3>Japanese Pitch Accent</h3>"
+        "<p><b>Version</b><br>{version}</p>"
+        "<p><b>License</b><br>"
         '<a href="{license_link}">{license_name}</a>'
-        '</p>'
-        '<p><b>Maintainer</b><br>{author}</p>'
-        '<p><b>Contributors</b><br>{contrib}</p>'
+        "</p>"
+        "<p><b>Maintainer</b><br>{author}</p>"
+        "<p><b>Contributors</b><br>{contrib}</p>"
         '<p><a href="{gh_link}">GitHub</a>'
-        '&nbsp;<b>&middot;</b>&nbsp;'
+        "&nbsp;<b>&middot;</b>&nbsp;"
         '<a href="{aw_link}">AnkiWeb</a></p>'
-        '</center>'
+        "</center>"
     ).format(
         version=__version__,
         license_link=license_link,
         license_name=__license__,
         author=__author__,
-        contrib='<br>'.join(__credits__),
+        contrib="<br>".join(__credits__),
         gh_link=gh_link,
-        aw_link=aw_link
+        aw_link=aw_link,
     )
 
     showText(
         info_text,
-        title='About',
-        type='rich',
+        title="About",
+        type="rich",
         minWidth=0,
         minHeight=0,
     )
 
 
 def add_pitch_dialog():
-    """ Dialog for bulk adding pitch accent illustrations to notes.
-    """
+    """Dialog for bulk adding pitch accent illustrations to notes."""
 
     # load pitch dict
     acc_dict = get_accent_dict()
 
     # load user pitch dict if present
-    acc_dict.update(
-        get_user_accent_dict()
-    )
+    acc_dict.update(get_user_accent_dict())
 
     # figure out collection structure
-    deck_id = select_deck_id('Which deck would you like to extend?')
+    deck_id = select_deck_id("Which deck would you like to extend?")
     if deck_id is None:
         return
     note_type_ids = get_note_type_ids(deck_id)
     if len(note_type_ids) > 1:
         note_type_id = select_note_type_id(note_type_ids)
     elif len(note_type_ids) < 1:
-        showInfo('No cards found in deck.')
+        showInfo("No cards found in deck.")
         return
     else:
         note_type_id = note_type_ids[0]
@@ -96,7 +102,7 @@ def add_pitch_dialog():
         return
     note_ids = get_note_ids(deck_id, note_type_id)
     if len(note_ids) == 0:
-        showInfo('No cards found for selected note type.')
+        showInfo("No cards found for selected note type.")
         return
     expr_idx, rdng_idx, out_idx = select_note_fields_add(note_type_id)
     if None in [expr_idx, rdng_idx, out_idx]:
@@ -107,104 +113,80 @@ def add_pitch_dialog():
         acc_dict, note_ids, expr_idx, rdng_idx, out_idx
     )
     report_text = (
-        'done :)\n'
-        'skipped {} already annotated notes\n'
-        'updated {} notes\n'
-        'failed to generate {} annotations\n'
-        'could not find {} expressions'
-    ).format(
-        n_adone, n_updt, n_sfail, len(nf_lst)
-    )
-    showInfo(
-        report_text,
-        title='Bulk add results'
-    )
+        "done :)\n"
+        "skipped {} already annotated notes\n"
+        "updated {} notes\n"
+        "failed to generate {} annotations\n"
+        "could not find {} expressions"
+    ).format(n_adone, n_updt, n_sfail, len(nf_lst))
+    showInfo(report_text, title="Bulk add results")
 
 
 def add_user_pitch_dialog():
-    """ Popup explaining how to manually set pitch accent illustrations.
-    """
+    """Popup explaining how to manually set pitch accent illustrations."""
 
     icon_img = (
-        'data:image/svg+xml;base64,PHN2ZwogICB2aWV3Qm94PSIwIDAgMjIuNSAyMi41Igo'
-        'gICBoZWlnaHQ9IjIyLjUiCiAgIHdpZHRoPSIyMi41IgogICBjbGFzcz0icGl0Y2giPgog'
-        'IDxwYXRoCiAgICAgaWQ9InBhdGg4NTIiCiAgICAgc3R5bGU9ImZpbGw6bm9uZTtzdHJva'
-        '2U6IzAwMDAwMDtzdHJva2Utd2lkdGg6MS41IgogICAgIGQ9Ik0gMi41LDE3LjUgMjAsNS'
-        'IgLz4KICA8Y2lyY2xlCiAgICAgaWQ9ImNpcmNsZTg1NCIKICAgICBzdHlsZT0ib3BhY2l'
-        '0eToxO2ZpbGw6IzAwMDAwMDtzdHJva2Utd2lkdGg6MSIKICAgICBjeT0iMTcuNSIKICAg'
-        'ICBjeD0iMi41IgogICAgIHI9IjIuNSIgLz4KICA8Y2lyY2xlCiAgICAgaWQ9ImNpcmNsZ'
-        'Tg1NiIKICAgICBzdHlsZT0ib3BhY2l0eToxO2ZpbGw6IzAwMDAwMDtzdHJva2Utd2lkdG'
-        'g6MSIKICAgICBjeT0iNSIKICAgICBjeD0iMjAiCiAgICAgcj0iMi41IiAvPgogIDxjaXJ'
-        'jbGUKICAgICBpZD0iY2lyY2xlODU4IgogICAgIHN0eWxlPSJvcGFjaXR5OjE7ZmlsbDoj'
-        'ZmZmZmZmO3N0cm9rZS13aWR0aDoxIgogICAgIGN5PSI1IgogICAgIGN4PSIyMCIKICAgI'
-        'CByPSIxLjYyNSIgLz4KPC9zdmc+Cg=='
+        "data:image/svg+xml;base64,PHN2ZwogICB2aWV3Qm94PSIwIDAgMjIuNSAyMi41Igo"
+        "gICBoZWlnaHQ9IjIyLjUiCiAgIHdpZHRoPSIyMi41IgogICBjbGFzcz0icGl0Y2giPgog"
+        "IDxwYXRoCiAgICAgaWQ9InBhdGg4NTIiCiAgICAgc3R5bGU9ImZpbGw6bm9uZTtzdHJva"
+        "2U6IzAwMDAwMDtzdHJva2Utd2lkdGg6MS41IgogICAgIGQ9Ik0gMi41LDE3LjUgMjAsNS"
+        "IgLz4KICA8Y2lyY2xlCiAgICAgaWQ9ImNpcmNsZTg1NCIKICAgICBzdHlsZT0ib3BhY2l"
+        "0eToxO2ZpbGw6IzAwMDAwMDtzdHJva2Utd2lkdGg6MSIKICAgICBjeT0iMTcuNSIKICAg"
+        "ICBjeD0iMi41IgogICAgIHI9IjIuNSIgLz4KICA8Y2lyY2xlCiAgICAgaWQ9ImNpcmNsZ"
+        "Tg1NiIKICAgICBzdHlsZT0ib3BhY2l0eToxO2ZpbGw6IzAwMDAwMDtzdHJva2Utd2lkdG"
+        "g6MSIKICAgICBjeT0iNSIKICAgICBjeD0iMjAiCiAgICAgcj0iMi41IiAvPgogIDxjaXJ"
+        "jbGUKICAgICBpZD0iY2lyY2xlODU4IgogICAgIHN0eWxlPSJvcGFjaXR5OjE7ZmlsbDoj"
+        "ZmZmZmZmO3N0cm9rZS13aWR0aDoxIgogICAgIGN5PSI1IgogICAgIGN4PSIyMCIKICAgI"
+        "CByPSIxLjYyNSIgLz4KPC9zdmc+Cg=="
     )
 
     info_text = (
-        '<p>When adding or editing cards, click the pitch accent icon located '
-        'on the right hand side of the text formatting buttons to manually '
-        'insert, overwrite, or remove the pitch accent.<br></p>'
-        '<table><tr>'
+        "<p>When adding or editing cards, click the pitch accent icon located "
+        "on the right hand side of the text formatting buttons to manually "
+        "insert, overwrite, or remove the pitch accent.<br></p>"
+        "<table><tr>"
         '<td align="left" valign="middle">'
         '<img src="{}"></td>'
         '<td valign="middle" align="center">&nbsp;&larr; icon to look for</td>'
-        '</tr></table>'
-    ).format(
-        icon_img
-    )
+        "</tr></table>"
+    ).format(icon_img)
 
-    showInfo(
-        info_text,
-        title='Manually add/edit/remove',
-        textFormat='rich'
-    )
+    showInfo(info_text, title="Manually add/edit/remove", textFormat="rich")
 
 
 def show_custom_db_path_dialog():
-    """ Popup explaining the user custom dictionary.
-    """
+    """Popup explaining the user custom dictionary."""
 
-    user_pitch_csv_path = os.path.join(
-        get_plugin_dir_path(),
-        'user_pitchdb.csv'
-    )
+    user_pitch_csv_path = os.path.join(get_plugin_dir_path(), "user_pitchdb.csv")
 
     custom_db_text = (
-        'You can extend and overwrite pitch accent patterns using the'
+        "You can extend and overwrite pitch accent patterns using the"
         ' file "{}". The file has to be three columns (expression,'
-        ' reading, pitch accent pattern) separated by TAB characters.'
-    ).format(
-        user_pitch_csv_path
-    )
-    showInfo(
-        custom_db_text,
-        title='Custom DB path'
-    )
+        " reading, pitch accent pattern) separated by TAB characters."
+    ).format(user_pitch_csv_path)
+    showInfo(custom_db_text, title="Custom DB path")
 
 
 def remove_user_pitch_dialog():
-    """ Dialog for bulk removing user added custom pitch accent
-        illustrations from nodes.
+    """Dialog for bulk removing user added custom pitch accent
+    illustrations from nodes.
     """
 
     return remove_pitch_dialog(user_set=True)
 
 
 def remove_pitch_dialog(user_set=False):
-    """ Dialog for bulk removing pitch accent illustrations from nodes.
-    """
+    """Dialog for bulk removing pitch accent illustrations from nodes."""
 
     # figure out collection structure
-    deck_id = select_deck_id(
-        'From which deck would you like to remove?'
-    )
+    deck_id = select_deck_id("From which deck would you like to remove?")
     if deck_id is None:
         return
     note_type_ids = get_note_type_ids(deck_id)
     if len(note_type_ids) > 1:
         note_type_id = select_note_type_id(note_type_ids)
     elif len(note_type_ids) < 1:
-        showInfo('No cards found in deck.')
+        showInfo("No cards found in deck.")
         return
     else:
         note_type_id = note_type_ids[0]
@@ -212,7 +194,7 @@ def remove_pitch_dialog(user_set=False):
         return
     note_ids = get_note_ids(deck_id, note_type_id)
     if len(note_ids) == 0:
-        showInfo('No cards found for selected note type.')
+        showInfo("No cards found for selected note type.")
         return
     del_idx = select_note_fields_del(note_type_id)
     if del_idx is None:
@@ -221,38 +203,30 @@ def remove_pitch_dialog(user_set=False):
     # remove from notes
     n_adone, n_updt = remove_pitch(note_ids, del_idx, user_set)
     report_text = (
-        'done :)\n'
-        'skipped {} notes w/o accent annotation\n'
-        'updated {} notes'
-    ).format(
-        n_adone,
-        n_updt
-    )
-    showInfo(
-        report_text,
-        title='Bulk remove results'
-    )
+        "done :)\n" "skipped {} notes w/o accent annotation\n" "updated {} notes"
+    ).format(n_adone, n_updt)
+    showInfo(report_text, title="Bulk remove results")
 
 
 def set_pitch_manually_dialog(editor):
-    """ Dialog for manually setting the pitch accent illustration
-        in the currently selected editor field.
+    """Dialog for manually setting the pitch accent illustration
+    in the currently selected editor field.
     """
 
     if editor.web.editor.currentField is None:
-        showInfo('A field needs to be selected')
+        showInfo("A field needs to be selected")
         return
 
     # get user input
-    hira, hira_succeeded = getText(
-        'Enter the reading to be set. (Example: はな)'
-    )
+    hira, hira_succeeded = getText("Enter the reading to be set. (Example: はな)")
     if not hira_succeeded:
         return
 
     LH_patt, LH_patt_succeeded = getText(
-        ('Enter the pitch accent pattern as a sequence of \'H\'s and \'L\'s. '
-         '(Example: LHL)')
+        (
+            "Enter the pitch accent pattern as a sequence of 'H's and 'L's. "
+            "(Example: LHL)"
+        )
     )
     if not LH_patt_succeeded:
         return
@@ -261,8 +235,8 @@ def set_pitch_manually_dialog(editor):
 
 
 def set_pitch_automatically(editor):
-    """ Automatically set the pitch accent illustration
-        in the currently selected editor field.
+    """Automatically set the pitch accent illustration
+    in the currently selected editor field.
     """
 
     # try to determine note fields
@@ -288,111 +262,100 @@ def set_pitch_automatically(editor):
             # found all that we needed
             break
     if expr_guess is None:
-        showInfo(
-            'Could not identify expression',
-            title='Card parsing failure'
-        )
+        showInfo("Could not identify expression", title="Card parsing failure")
         return
     if reading_guess is None:
         # could imagine user that just does expr to meaning (with no
         # field for reading) and then wants to add pitch accent illustrations
-        reading_guess = ''
+        reading_guess = ""
 
     # load pitch dict
     acc_dict = get_accent_dict()
     # load user pitch dict if present
-    acc_dict.update(
-        get_user_accent_dict()
-    )
+    acc_dict.update(get_user_accent_dict())
     patt = get_acc_patt(expr_guess, reading_guess, [acc_dict])
     if not patt:
         showInfo(
-            'Could not find pitch for expression “{}”'.format(
-                expr_guess
-            ),
-            title='Card parsing failure'
+            "Could not find pitch for expression “{}”".format(expr_guess),
+            title="Card parsing failure",
         )
         return
     hira, LlHh_patt = patt
-    LH_patt = re.sub(r'[lh]', '', LlHh_patt)
+    LH_patt = re.sub(r"[lh]", "", LlHh_patt)
 
     set_pitch(editor, hira, LH_patt)
 
 
 def set_pitch(editor, hira, LH_patt):
-    """ Set the pitch accent illustration in the editor’s current
-        selected field according to the hiragana and low-high pattern
-        given.
+    """Set the pitch accent illustration in the editor’s current
+    selected field according to the hiragana and low-high pattern
+    given.
     """
 
     # get note data
     data = [
-        (fld, editor.mw.col.media.escapeImages(val))
-        for fld, val in editor.note.items()
+        (fld, editor.mw.col.media.escapeImages(val)) for fld, val in editor.note.items()
     ]
 
     # remove existing patt
     acc_patt = re.compile(
-        r'<!-- (user_)?accent_start -->.+<!-- (user_)?accent_end -->',
-        re.S
+        r"<!-- (user_)?accent_start -->.+<!-- (user_)?accent_end -->", re.S
     )
     old_field_val = data[editor.web.editor.currentField][1]
-    old_field_val_clean = re.sub(acc_patt, '', old_field_val)
+    old_field_val_clean = re.sub(acc_patt, "", old_field_val)
 
     # generate SVG
     svg = pitch_svg(hira, LH_patt)
     if len(old_field_val_clean) > 0:
-        separator = '<br><hr><br>'
+        separator = "<br><hr><br>"
     else:
-        separator = ''
-    new_field_val = (
-        '{}<!-- user_accent_start -->{}{}<!-- user_accent_end -->'
-        ).format(old_field_val_clean, separator, svg)
-    if hira == '' and LH_patt == '':
+        separator = ""
+    new_field_val = ("{}<!-- user_accent_start -->{}{}<!-- user_accent_end -->").format(
+        old_field_val_clean, separator, svg
+    )
+    if hira == "" and LH_patt == "":
         new_field_val = old_field_val_clean
 
     # add new patt
     data[editor.web.editor.currentField] = (
-        data[editor.web.editor.currentField][0],       # leave field name as is
-        new_field_val                                  # update field value
+        data[editor.web.editor.currentField][0],  # leave field name as is
+        new_field_val,  # update field value
     )
-    js = 'setFields(%s); setFonts(%s); focusField(%s); setNoteId(%s)' % (
+    js = "setFields(%s); setFonts(%s); focusField(%s); setNoteId(%s)" % (
         json.dumps(data),
         json.dumps(editor.fonts()),
         json.dumps(editor.web.editor.currentField),
-        json.dumps(editor.note.id)
+        json.dumps(editor.note.id),
     )
     js = gui_hooks.editor_will_load_note(js, editor.note, editor)
     editor.web.eval(js)
 
 
 def add_set_pitch_buttons(buttons, editor):
-    """ Add pitch buttons to editor menu.
-    """
+    """Add pitch buttons to editor menu."""
 
     # manual mode
-    icon_path_m = os.path.join(get_plugin_dir_path(), 'icon_manual.png')
+    icon_path_m = os.path.join(get_plugin_dir_path(), "icon_manual.png")
     m_btn = editor.addButton(
         icon_path_m,
-        'manualpitch',
+        "manualpitch",
         set_pitch_manually_dialog,
-        tip='set pitch accent manually'
+        tip="set pitch accent manually",
     )
     buttons.append(m_btn)
     # auto mode
-    icon_path_a = os.path.join(get_plugin_dir_path(), 'icon_auto.png')
+    icon_path_a = os.path.join(get_plugin_dir_path(), "icon_auto.png")
     a_btn = editor.addButton(
         icon_path_a,
-        'autopitch',
+        "autopitch",
         set_pitch_automatically,
-        tip='set pitch accent automatically'
+        tip="set pitch accent automatically",
     )
     buttons.append(a_btn)
 
 
 def pre_load_pitch_data(col):
-    """ Pre-load pitch accent dictionaries (will get cached)
-    """
+    """Pre-load pitch accent dictionaries (will get cached)"""
 
     _ = get_accent_dict()
     _ = get_user_accent_dict()
@@ -401,13 +364,13 @@ def pre_load_pitch_data(col):
 
 
 # add menu items
-pa_menu = QMenu('Pitch Accent', mw)
-pa_menu_add = pa_menu.addAction('bulk add')
-pa_menu_remove = pa_menu.addAction('bulk remove')
-pa_menu_add_user = pa_menu.addAction('manually add/edit/remove')
-pa_menu_remove_user = pa_menu.addAction('remove all manually set')
-pa_menu_custom_db_path = pa_menu.addAction('show custom DB path')
-pa_menu_about = pa_menu.addAction('about')
+pa_menu = QMenu("Pitch Accent", mw)
+pa_menu_add = pa_menu.addAction("bulk add")
+pa_menu_remove = pa_menu.addAction("bulk remove")
+pa_menu_add_user = pa_menu.addAction("manually add/edit/remove")
+pa_menu_remove_user = pa_menu.addAction("remove all manually set")
+pa_menu_custom_db_path = pa_menu.addAction("show custom DB path")
+pa_menu_about = pa_menu.addAction("about")
 # add triggers
 pa_menu_add.triggered.connect(add_pitch_dialog)
 pa_menu_remove.triggered.connect(remove_pitch_dialog)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -37,16 +37,17 @@ from .util import (
     clean_japanese_from_note_field,
 )
 from .draw_pitch import pitch_svg
+from .types import HiraganaStr
 
 
-def about_dialog():
+def about_dialog() -> None:
     """Popup displaying information about the add-on."""
 
-    gh_link = "https://github.com/IllDepence/anki_add_pitch_plugin"
-    aw_link = "https://ankiweb.net/shared/info/148002038"
-    license_link = gh_link + "/blob/master/LICENSE"
+    gh_link: str = "https://github.com/IllDepence/anki_add_pitch_plugin"
+    aw_link: str = "https://ankiweb.net/shared/info/148002038"
+    license_link: str = gh_link + "/blob/master/LICENSE"
 
-    info_text = (
+    info_text: str = (
         "<center>"
         "<h3>Japanese Pitch Accent</h3>"
         "<p><b>Version</b><br>{version}</p>"
@@ -78,7 +79,7 @@ def about_dialog():
     )
 
 
-def add_pitch_dialog():
+def add_pitch_dialog() -> None:
     """Dialog for bulk adding pitch accent illustrations to notes."""
 
     # load pitch dict
@@ -106,7 +107,7 @@ def add_pitch_dialog():
         showInfo("No cards found for selected note type.")
         return
     expr_idx, rdng_idx, out_idx = select_note_fields_add(note_type_id)
-    if None in [expr_idx, rdng_idx, out_idx]:
+    if expr_idx is None or rdng_idx is None or out_idx is None:
         return
 
     # extend notes
@@ -258,7 +259,7 @@ def set_pitch_automatically(editor):
         if all_hira_match and reading_guess is None:
             # if first continuous block is all hiragana, treat as reading
             # and don’t override afterwards
-            reading_guess = all_hira_match.group(0)
+            reading_guess = HiraganaStr(all_hira_match.group(0))
         if expr_guess is not None and reading_guess is not None:
             # found all that we needed
             break
@@ -268,7 +269,7 @@ def set_pitch_automatically(editor):
     if reading_guess is None:
         # could imagine user that just does expr to meaning (with no
         # field for reading) and then wants to add pitch accent illustrations
-        reading_guess = ""
+        reading_guess = HiraganaStr("")
 
     # load pitch dict
     acc_dict = get_accent_dict()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -73,9 +73,9 @@ def about_dialog() -> None:
     showText(
         info_text,
         title="About",
-        type="rich",
-        minWidth=0,
-        minHeight=0,
+        type="html",
+        minWidth=200,
+        minHeight=340,
     )
 
 

--- a/src/_constants.py
+++ b/src/_constants.py
@@ -1,35 +1,32 @@
-""" Definition of consonants
-"""
+"""Definition of consonants"""
 
 import re
 
 
 re_ja_patt = re.compile(
-    r'['
-    r'\u3041-\u3096'  # hiragana
-    r'\u30A0-\u30FF'  # katakana
-    r'\u3400-\u4DB5\u4E00-\u9FCB\uF900-\uFA6A'  # kanji
-    r'\u3005'  # 々
+    r"["
+    r"\u3041-\u3096"  # hiragana
+    r"\u30A0-\u30FF"  # katakana
+    r"\u3400-\u4DB5\u4E00-\u9FCB\uF900-\uFA6A"  # kanji
+    r"\u3005"  # 々
     # r'\u2026\u301C'  # …〜 (might be used to indicate affixes)
     #                        (disabled — causes more problems than benefits)
-    r']+'
+    r"]+"
 )
 re_variation_selectors_patt = re.compile(
-    r'['
-    r'\U000E0100-\U000E013D'  # variation selectors [1]
-    r']+'
+    r"["
+    r"\U000E0100-\U000E013D"  # variation selectors [1]
+    r"]+"
 )
 # [1] https://en.wikipedia.org/wiki/Variation_Selectors_Supplement
-re_bracketed_content_patt = re.compile(
-    r'[\[\(\{][^\]\)\}]*[\]\)\}]'
-)
+re_bracketed_content_patt = re.compile(r"[\[\(\{][^\]\)\}]*[\]\)\}]")
 re_hira_patt = re.compile(
-    r'['
-    r'\u3041-\u3096'  # hiragana
-    r']+'
+    r"["
+    r"\u3041-\u3096"  # hiragana
+    r"]+"
 )
 re_all_hira_patt = re.compile(
-    r'^['
-    r'\u3041-\u3096'  # hiragana
-    r']+$'
+    r"^["
+    r"\u3041-\u3096"  # hiragana
+    r"]+$"
 )

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,4 +1,3 @@
-""" Version information
-"""
+"""Version information"""
 
-__version__ = '0.9.1'
+__version__ = "0.9.1"

--- a/src/draw_pitch.py
+++ b/src/draw_pitch.py
@@ -2,19 +2,35 @@ import sys
 
 
 def hira_to_mora(hira):
-    """ Example:
-            in:  'しゅんかしゅうとう'
-            out: ['しゅ', 'ん', 'か', 'しゅ', 'う', 'と', 'う']
+    """Example:
+    in:  'しゅんかしゅうとう'
+    out: ['しゅ', 'ん', 'か', 'しゅ', 'う', 'と', 'う']
     """
 
     mora_arr = []
-    combiners = ['ゃ', 'ゅ', 'ょ', 'ぁ', 'ぃ', 'ぅ', 'ぇ', 'ぉ',
-                 'ャ', 'ュ', 'ョ', 'ァ', 'ィ', 'ゥ', 'ェ', 'ォ']
+    combiners = [
+        "ゃ",
+        "ゅ",
+        "ょ",
+        "ぁ",
+        "ぃ",
+        "ぅ",
+        "ぇ",
+        "ぉ",
+        "ャ",
+        "ュ",
+        "ョ",
+        "ァ",
+        "ィ",
+        "ゥ",
+        "ェ",
+        "ォ",
+    ]
 
     i = 0
     while i < len(hira):
-        if i+1 < len(hira) and hira[i+1] in combiners:
-            mora_arr.append('{}{}'.format(hira[i], hira[i+1]))
+        if i + 1 < len(hira) and hira[i + 1] in combiners:
+            mora_arr.append("{}{}".format(hira[i], hira[i + 1]))
             i += 2
         else:
             mora_arr.append(hira[i])
@@ -23,95 +39,100 @@ def hira_to_mora(hira):
 
 
 def circle(x, y, o=False):
-    r = (
-        '<circle r="5" cx="{}" cy="{}" style="opacity:1;fill:#000;" />'
-    ).format(x, y)
+    r = ('<circle r="5" cx="{}" cy="{}" style="opacity:1;fill:#000;" />').format(x, y)
     if o:
-        r += ('<circle r="3.25" cx="{}" cy="{}" style="opacity:1;fill:#fff;"'
-              '/>').format(x, y)
+        r += (
+            '<circle r="3.25" cx="{}" cy="{}" style="opacity:1;fill:#fff;"' "/>"
+        ).format(x, y)
     return r
 
 
 def text(x, mora):
     # letter positioning tested with Noto Sans CJK JP
     if len(mora) == 1:
-        return ('<text x="{}" y="67.5" style="font-size:20px;font-family:sans-'
-                'serif;fill:#000;">{}</text>').format(x, mora)
+        return (
+            '<text x="{}" y="67.5" style="font-size:20px;font-family:sans-'
+            'serif;fill:#000;">{}</text>'
+        ).format(x, mora)
     else:
-        return ('<text x="{}" y="67.5" style="font-size:20px;font-family:sans-'
-                'serif;fill:#000;">{}</text><text x="{}" y="67.5" style="font-'
-                'size:14px;font-family:sans-serif;fill:#000;">{}</text>'
-                ).format(x-5, mora[0], x+12, mora[1])
+        return (
+            '<text x="{}" y="67.5" style="font-size:20px;font-family:sans-'
+            'serif;fill:#000;">{}</text><text x="{}" y="67.5" style="font-'
+            'size:14px;font-family:sans-serif;fill:#000;">{}</text>'
+        ).format(x - 5, mora[0], x + 12, mora[1])
 
 
 def path(x, y, typ, step_width):
-    if typ == 's':  # straight
-        delta = '{},0'.format(step_width)
-    elif typ == 'u':  # up
-        delta = '{},-25'.format(step_width)
-    elif typ == 'd':  # down
-        delta = '{},25'.format(step_width)
-    return ('<path d="m {},{} {}" style="fill:none;stroke:#000;stroke-width'
-            ':1.5;" />').format(x, y, delta)
+    if typ == "s":  # straight
+        delta = "{},0".format(step_width)
+    elif typ == "u":  # up
+        delta = "{},-25".format(step_width)
+    elif typ == "d":  # down
+        delta = "{},25".format(step_width)
+    return (
+        '<path d="m {},{} {}" style="fill:none;stroke:#000;stroke-width' ':1.5;" />'
+    ).format(x, y, delta)
 
 
 def pitch_svg(word, patt, silent=False):
-    """ Draw pitch accent patterns in SVG
+    """Draw pitch accent patterns in SVG
 
-        Examples:
-            はし HLL (箸)
-            はし LHL (橋)
-            はし LHH (端)
+    Examples:
+        はし HLL (箸)
+        はし LHL (橋)
+        はし LHH (端)
     """
 
     mora = hira_to_mora(word)
 
     if len(patt) - len(mora) != 1 and not silent:
-        print(('pattern should be number of morae + 1 (got: {}, {})'
-               ).format(word, patt))
+        print(
+            ("pattern should be number of morae + 1 (got: {}, {})").format(word, patt)
+        )
     positions = max(len(mora), len(patt))
     step_width = 35
     margin_lr = 16
-    svg_width = max(0, ((positions-1) * step_width) + (margin_lr*2))
+    svg_width = max(0, ((positions - 1) * step_width) + (margin_lr * 2))
 
-    svg = ('<svg class="pitch" width="{0}px" height="75px" viewBox="0 0 {0} 75'
-           '">').format(svg_width)
+    svg = (
+        '<svg class="pitch" width="{0}px" height="75px" viewBox="0 0 {0} 75' '">'
+    ).format(svg_width)
 
-    chars = ''
+    chars = ""
     for pos, mor in enumerate(mora):
         x_center = margin_lr + (pos * step_width)
-        chars += text(x_center-11, mor)
+        chars += text(x_center - 11, mor)
 
-    circles = ''
-    paths = ''
+    circles = ""
+    paths = ""
     prev_center = (None, None)
     for pos, accent in enumerate(patt):
         x_center = margin_lr + (pos * step_width)
-        if accent in ['H', 'h', '1', '2']:
+        if accent in ["H", "h", "1", "2"]:
             y_center = 5
-        elif accent in ['L', 'l', '0']:
+        elif accent in ["L", "l", "0"]:
             y_center = 30
         circles += circle(x_center, y_center, pos >= len(mora))
         if pos > 0:
             if prev_center[1] == y_center:
-                path_typ = 's'
+                path_typ = "s"
             elif prev_center[1] < y_center:
-                path_typ = 'd'
+                path_typ = "d"
             elif prev_center[1] > y_center:
-                path_typ = 'u'
+                path_typ = "u"
             paths += path(prev_center[0], prev_center[1], path_typ, step_width)
         prev_center = (x_center, y_center)
 
     svg += chars
     svg += paths
     svg += circles
-    svg += '</svg>'
+    svg += "</svg>"
 
     return svg
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if len(sys.argv) != 3:
-        print('usage: python3 draw_pitch.py <word> <patt>')
+        print("usage: python3 draw_pitch.py <word> <patt>")
         sys.exit()
     print(pitch_svg(sys.argv[1], sys.argv[2], silent=True))

--- a/src/draw_pitch.py
+++ b/src/draw_pitch.py
@@ -105,13 +105,15 @@ def pitch_svg(word, patt, silent=False):
 
     circles = ""
     paths = ""
-    prev_center = (None, None)
     for pos, accent in enumerate(patt):
         x_center = margin_lr + (pos * step_width)
         if accent in ["H", "h", "1", "2"]:
             y_center = 5
         elif accent in ["L", "l", "0"]:
             y_center = 30
+        else:
+            # in case of an invalid accent mark, annotate in the center
+            y_center = 17.5
         circles += circle(x_center, y_center, pos >= len(mora))
         if pos > 0:
             if prev_center[1] == y_center:

--- a/src/draw_pitch.py
+++ b/src/draw_pitch.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Tuple
 from .types import (
     KanaStr,
     MoraList,
@@ -24,13 +25,14 @@ def hira_to_mora(hira: KanaStr) -> MoraList:
     # fmt: on
 
     i = 0
+    mora: KanaStr
     while i < len(hira):
         if i + 1 < len(hira) and hira[i + 1] in combiners:
-            mora: KanaStr = KanaStr("{}{}".format(hira[i], hira[i + 1]))
+            mora = KanaStr("{}{}".format(hira[i], hira[i + 1]))
             mora_arr.append(mora)
             i += 2
         else:
-            mora: KanaStr = KanaStr(hira[i])
+            mora = KanaStr(hira[i])
             mora_arr.append(mora)
             i += 1
     return mora_arr
@@ -100,19 +102,19 @@ def pitch_svg(
     margin_lr: int = 16
     svg_width: int = max(0, ((positions - 1) * step_width) + (margin_lr * 2))
 
-    svg = SvgStr(
-        (
-            '<svg class="pitch" width="{0}px" height="75px" viewBox="0 0 {0} 75' '">'
-        ).format(svg_width)
-    )
+    svg: str = (
+        '<svg class="pitch" width="{0}px" height="75px" viewBox="0 0 {0} 75' '">'
+    ).format(svg_width)
 
-    chars = ""
+    chars: str = ""
     for pos, mor in enumerate(mora):
         x_center = margin_lr + (pos * step_width)
         chars += text(x_center - 11, mor)
 
-    circles = ""
-    paths = ""
+    circles: str = ""
+    paths: str = ""
+    prev_center: Tuple[int, int]
+    path_typ: PitchChangeDirection
     for pos, accent in enumerate(patt):
         x_center = margin_lr + (pos * step_width)
         if accent in ["H", "h", "1", "2"]:

--- a/src/draw_pitch.py
+++ b/src/draw_pitch.py
@@ -15,24 +15,13 @@ def hira_to_mora(hira: KanaStr) -> MoraList:
     """
 
     mora_arr: MoraList = []
+    # below is more readable in two lines; don't auto-format
+    # fmt: off
     combiners = [
-        "ゃ",
-        "ゅ",
-        "ょ",
-        "ぁ",
-        "ぃ",
-        "ぅ",
-        "ぇ",
-        "ぉ",
-        "ャ",
-        "ュ",
-        "ョ",
-        "ァ",
-        "ィ",
-        "ゥ",
-        "ェ",
-        "ォ",
+        "ゃ", "ゅ", "ょ", "ぁ", "ぃ", "ぅ", "ぇ", "ぉ",
+        "ャ", "ュ", "ョ", "ァ", "ィ", "ゥ", "ェ", "ォ",
     ]
+    # fmt: on
 
     i = 0
     while i < len(hira):

--- a/src/draw_pitch.py
+++ b/src/draw_pitch.py
@@ -1,5 +1,4 @@
 import sys
-from typing import Tuple
 from .types import (
     KanaStr,
     MoraList,
@@ -113,7 +112,7 @@ def pitch_svg(
 
     circles: str = ""
     paths: str = ""
-    prev_center: Tuple[int, int]
+    prev_center: tuple[int, int]
     path_typ: PitchChangeDirection
     for pos, accent in enumerate(patt):
         x_center = margin_lr + (pos * step_width)

--- a/src/draw_pitch.py
+++ b/src/draw_pitch.py
@@ -1,13 +1,20 @@
 import sys
+from .types import (
+    KanaStr,
+    MoraList,
+    PitchAccentNotationPerMora,
+    SvgStr,
+    PitchChangeDirection,
+)
 
 
-def hira_to_mora(hira):
+def hira_to_mora(hira: KanaStr) -> MoraList:
     """Example:
     in:  'しゅんかしゅうとう'
     out: ['しゅ', 'ん', 'か', 'しゅ', 'う', 'と', 'う']
     """
 
-    mora_arr = []
+    mora_arr: MoraList = []
     combiners = [
         "ゃ",
         "ゅ",
@@ -30,51 +37,61 @@ def hira_to_mora(hira):
     i = 0
     while i < len(hira):
         if i + 1 < len(hira) and hira[i + 1] in combiners:
-            mora_arr.append("{}{}".format(hira[i], hira[i + 1]))
+            mora: KanaStr = KanaStr("{}{}".format(hira[i], hira[i + 1]))
+            mora_arr.append(mora)
             i += 2
         else:
-            mora_arr.append(hira[i])
+            mora: KanaStr = KanaStr(hira[i])
+            mora_arr.append(mora)
             i += 1
     return mora_arr
 
 
-def circle(x, y, o=False):
+def circle(x: int, y: int, o: bool = False) -> SvgStr:
     r = ('<circle r="5" cx="{}" cy="{}" style="opacity:1;fill:#000;" />').format(x, y)
     if o:
         r += (
             '<circle r="3.25" cx="{}" cy="{}" style="opacity:1;fill:#fff;"' "/>"
         ).format(x, y)
-    return r
+    return SvgStr(r)
 
 
-def text(x, mora):
+def text(x: int, mora: KanaStr) -> SvgStr:
     # letter positioning tested with Noto Sans CJK JP
     if len(mora) == 1:
-        return (
-            '<text x="{}" y="67.5" style="font-size:20px;font-family:sans-'
-            'serif;fill:#000;">{}</text>'
-        ).format(x, mora)
+        return SvgStr(
+            (
+                '<text x="{}" y="67.5" style="font-size:20px;font-family:sans-'
+                'serif;fill:#000;">{}</text>'
+            ).format(x, mora)
+        )
     else:
-        return (
-            '<text x="{}" y="67.5" style="font-size:20px;font-family:sans-'
-            'serif;fill:#000;">{}</text><text x="{}" y="67.5" style="font-'
-            'size:14px;font-family:sans-serif;fill:#000;">{}</text>'
-        ).format(x - 5, mora[0], x + 12, mora[1])
+        return SvgStr(
+            (
+                '<text x="{}" y="67.5" style="font-size:20px;font-family:sans-'
+                'serif;fill:#000;">{}</text><text x="{}" y="67.5" style="font-'
+                'size:14px;font-family:sans-serif;fill:#000;">{}</text>'
+            ).format(x - 5, mora[0], x + 12, mora[1])
+        )
 
 
-def path(x, y, typ, step_width):
+def path(x: int, y: int, typ: PitchChangeDirection, step_width: int) -> SvgStr:
     if typ == "s":  # straight
         delta = "{},0".format(step_width)
     elif typ == "u":  # up
         delta = "{},-25".format(step_width)
     elif typ == "d":  # down
         delta = "{},25".format(step_width)
-    return (
-        '<path d="m {},{} {}" style="fill:none;stroke:#000;stroke-width' ':1.5;" />'
-    ).format(x, y, delta)
+    return SvgStr(
+        (
+            '<path d="m {},{} {}" style="fill:none;stroke:#000;stroke-width' ':1.5;" />'
+        ).format(x, y, delta)
+    )
 
 
-def pitch_svg(word, patt, silent=False):
+def pitch_svg(
+    word: KanaStr, patt: PitchAccentNotationPerMora, silent: bool = False
+) -> SvgStr:
     """Draw pitch accent patterns in SVG
 
     Examples:
@@ -89,14 +106,16 @@ def pitch_svg(word, patt, silent=False):
         print(
             ("pattern should be number of morae + 1 (got: {}, {})").format(word, patt)
         )
-    positions = max(len(mora), len(patt))
-    step_width = 35
-    margin_lr = 16
-    svg_width = max(0, ((positions - 1) * step_width) + (margin_lr * 2))
+    positions: int = max(len(mora), len(patt))
+    step_width: int = 35
+    margin_lr: int = 16
+    svg_width: int = max(0, ((positions - 1) * step_width) + (margin_lr * 2))
 
-    svg = (
-        '<svg class="pitch" width="{0}px" height="75px" viewBox="0 0 {0} 75' '">'
-    ).format(svg_width)
+    svg = SvgStr(
+        (
+            '<svg class="pitch" width="{0}px" height="75px" viewBox="0 0 {0} 75' '">'
+        ).format(svg_width)
+    )
 
     chars = ""
     for pos, mor in enumerate(mora):
@@ -113,7 +132,7 @@ def pitch_svg(word, patt, silent=False):
             y_center = 30
         else:
             # in case of an invalid accent mark, annotate in the center
-            y_center = 17.5
+            y_center = 17
         circles += circle(x_center, y_center, pos >= len(mora))
         if pos > 0:
             if prev_center[1] == y_center:
@@ -130,11 +149,14 @@ def pitch_svg(word, patt, silent=False):
     svg += circles
     svg += "</svg>"
 
-    return svg
+    return SvgStr(svg)
 
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:
         print("usage: python3 draw_pitch.py <word> <patt>")
         sys.exit()
-    print(pitch_svg(sys.argv[1], sys.argv[2], silent=True))
+
+    word: KanaStr = KanaStr(sys.argv[1])
+    patt: PitchAccentNotationPerMora = PitchAccentNotationPerMora(sys.argv[2])
+    print(pitch_svg(word, patt, silent=True))

--- a/src/types.py
+++ b/src/types.py
@@ -1,0 +1,26 @@
+from typing import NewType, Literal
+
+# A string containing only hiragana
+HiraganaStr = NewType("HiraganaStr", str)
+# A string containing only katakana
+KatakanaStr = NewType("KatakanaStr", str)
+# A string containing only kana
+KanaStr = NewType("KanaStr", str)
+# A list of kana strings each representing one mora (e.g. ['しゅ', 'ん'])
+MoraList = list[KanaStr]
+# An expression (vocabulary word) on an Anki card
+ExpressionStr = NewType("ExpressionStr", str)
+# Kana displayed with the pitch accent illustration
+PitchAccentDisplayKana = KanaStr
+# A character level pitch accent notation (拗音 as Hh or Ll; e.g. 旬 = LlHH)
+PitchAccentNotationPerCharacter = NewType("PitchAccentNotationPerCharacter", str)
+# A mora level pitch accent notation (e.g. 旬 = LHH)
+PitchAccentNotationPerMora = NewType("PitchAccentNotationPerMora", str)
+# Reading of an expression together with pitch accent information
+ReadingWithPitchPattern = tuple[PitchAccentDisplayKana, PitchAccentNotationPerCharacter]
+# A dictionary of expressions and their pitch accents
+AccentDict = dict[ExpressionStr, list[ReadingWithPitchPattern]]
+# An SVG string
+SvgStr = NewType("SvgStr", str)
+# Direction change of pitch (straight, up, down)
+PitchChangeDirection = Literal["s"] | Literal["u"] | Literal["d"]

--- a/src/types.py
+++ b/src/types.py
@@ -16,10 +16,25 @@ PitchAccentDisplayKana = KanaStr
 PitchAccentNotationPerCharacter = NewType("PitchAccentNotationPerCharacter", str)
 # A mora level pitch accent notation (e.g. 旬 = LHH)
 PitchAccentNotationPerMora = NewType("PitchAccentNotationPerMora", str)
-# Reading of an expression together with pitch accent information
-ReadingWithPitchPattern = tuple[PitchAccentDisplayKana, PitchAccentNotationPerCharacter]
+# A pitch accent notation (may be character or mora level)
+PitchAccentNotation = PitchAccentNotationPerCharacter | PitchAccentNotationPerMora
+# Reading of an expression together with character level pitch accent information
+ReadingWithPitchPatternPerCharacter = tuple[
+    PitchAccentDisplayKana, PitchAccentNotationPerCharacter
+]
+# Reading of an expression together with mora level pitch accent information
+ReadingWithPitchPatternPerMora = tuple[
+    PitchAccentDisplayKana, PitchAccentNotationPerMora
+]
+# Reading of an expression together with pitch accent information (may be character or mora level)
+ReadingWithPitchPattern = (
+    ReadingWithPitchPatternPerCharacter | ReadingWithPitchPatternPerMora
+)
 # A dictionary of expressions and their pitch accents
-AccentDict = dict[ExpressionStr, list[ReadingWithPitchPattern]]
+AccentDict = dict[
+    ExpressionStr,
+    list[ReadingWithPitchPatternPerCharacter | ReadingWithPitchPatternPerMora],
+]
 # An SVG string
 SvgStr = NewType("SvgStr", str)
 # Direction change of pitch (straight, up, down)

--- a/src/util.py
+++ b/src/util.py
@@ -437,7 +437,9 @@ def add_pitch(
     return not_found_list, num_updated, num_already_done, num_svg_fail
 
 
-def remove_pitch(note_ids, del_idx, user_set=False):
+def remove_pitch(
+    note_ids: list[NoteId], del_idx: int, user_set: bool = False
+) -> tuple[int, int]:
     """Remove pitch accent illustrations from a specified field.
 
     Returns stats on how that went.

--- a/src/util.py
+++ b/src/util.py
@@ -5,8 +5,22 @@ import re
 from aqt import mw
 from aqt.utils import Qt, QDialog, QVBoxLayout, QLabel, QListWidget, QDialogButtonBox
 from anki.utils import strip_html
+from anki.decks import DeckId
+from anki.cards import CardId
+from anki.notes import Note, NoteId
+from anki.models import NotetypeId, NotetypeDict
 from functools import lru_cache
 from .draw_pitch import pitch_svg
+from .types import (
+    HiraganaStr,
+    KatakanaStr,
+    ExpressionStr,
+    PitchAccentDisplayKana,
+    PitchAccentNotationPerCharacter,
+    PitchAccentNotationPerMora,
+    ReadingWithPitchPattern,
+    AccentDict,
+)
 from ._constants import (
     re_ja_patt,
     re_hira_patt,
@@ -15,10 +29,10 @@ from ._constants import (
 )
 
 
-def get_qt_version():
+def get_qt_version() -> int:
     """Return the version of Qt used by Anki."""
 
-    qt_ver = 5  # assume 5 for now
+    qt_ver: int = 5  # assume 5 for now
 
     if Qt.__module__ == "PyQt5.QtCore":
         # PyQt5
@@ -37,20 +51,20 @@ def get_qt_version():
     return qt_ver
 
 
-def get_plugin_dir_path():
+def get_plugin_dir_path() -> str:
     """Determine and return the path of the plugin directory."""
 
-    collection_path = mw.col.path
-    plugin_dir_name = __name__.split(".")[0]  # remove “.util”
+    collection_path: str = mw.col.path if mw.col else ""
+    plugin_dir_name: str = __name__.split(".")[0]  # remove “.util”
 
-    user_dir_path = os.path.split(collection_path)[0]
-    anki_dir_path = os.path.split(user_dir_path)[0]
-    plugin_dir_path = os.path.join(anki_dir_path, "addons21", plugin_dir_name)
+    user_dir_path: str = os.path.split(collection_path)[0]
+    anki_dir_path: str = os.path.split(user_dir_path)[0]
+    plugin_dir_path: str = os.path.join(anki_dir_path, "addons21", plugin_dir_name)
 
     return plugin_dir_path
 
 
-def customChooseList(msg, choices, startrow=0):
+def customChooseList(msg: str, choices: list[str], startrow: int = 0) -> int | None:
     """Copy of https://github.com/ankitects/anki/blob/main/
     qt/aqt/utils.py but with a cancel button and title
     parameter added.
@@ -91,13 +105,16 @@ def customChooseList(msg, choices, startrow=0):
     return c.currentRow()
 
 
-def select_deck_id(msg):
+def select_deck_id(msg: str) -> DeckId | None:
     """UI dialog that prints <msg> as a prompt to
     the user shows a list of all decks in the
     collection.
     Returns the ID of the selected deck or None
     if dialog is cancelled.
     """
+
+    if not mw.col:
+        return None
 
     decks = mw.col.decks.all()
     choices = [d["name"] for d in decks]
@@ -107,12 +124,15 @@ def select_deck_id(msg):
     return decks[choice_idx]["id"]
 
 
-def select_note_type_id(note_type_ids):
+def select_note_type_id(note_type_ids) -> NotetypeId | None:
     """UI dialog that prompts the user to select a
     note type.
     Returns the ID of the selected name type or
     None if dialog is cancelled.
     """
+
+    if not mw.col:
+        return None
 
     note_types = mw.col.models.all()
     choices = [
@@ -127,16 +147,23 @@ def select_note_type_id(note_type_ids):
 
 
 @lru_cache(maxsize=1)
-def get_accent_dict(path=None):
+def get_accent_dict(path: str | None = None) -> AccentDict:
 
     if path is None:
         # load the default pitch accent dict
         path = os.path.join(get_plugin_dir_path(), "wadoku_pitchdb.csv")
 
-    acc_dict = {}
+    acc_dict: dict[str, list[tuple[str, str]]] = {}
     with open(path, encoding="utf8") as f:
         for line in f:
-            orths_txt, hira, hz, accs_txt, patts_txt = line.strip().split("\u241e")
+            line_parts = line.strip().split("\u241e")
+            orths_txt: ExpressionStr = ExpressionStr(line_parts[0])
+            hira: HiraganaStr = HiraganaStr(line_parts[1])
+            # hz = line_parts[2]
+            # accs_txt = line_parts[3]
+            patts_txt: PitchAccentNotationPerCharacter = (
+                PitchAccentNotationPerCharacter(line_parts[4])
+            )
             orth_txts = orths_txt.split("\u241f")
             if clean_orth(orth_txts[0]) != orth_txts[0]:
                 orth_txts = [clean_orth(orth_txts[0])] + orth_txts
@@ -158,7 +185,7 @@ def get_accent_dict(path=None):
 
 
 @lru_cache(maxsize=1)
-def get_user_accent_dict(path=None):
+def get_user_accent_dict(path: str | None = None) -> AccentDict:
 
     if path is None:
         # load the user custom pitch accent dict
@@ -166,7 +193,7 @@ def get_user_accent_dict(path=None):
         if not os.path.isfile(path):
             return {}
 
-    acc_dict = {}
+    acc_dict: dict[str, list[tuple[str, str]]] = {}
     with open(path, encoding="utf8") as f:
         for line in f:
             orth, hira, patt = line.strip().split("\t")
@@ -177,22 +204,30 @@ def get_user_accent_dict(path=None):
     return acc_dict
 
 
-def get_note_type_ids(deck_id):
+def get_note_type_ids(deck_id: DeckId) -> list[NotetypeId]:
     """Return a list of the IDs of note types used
     in a deck.
     """
 
-    card_ids = mw.col.decks.cids(deck_id)
-    note_type_ids = set([mw.col.get_card(cid).note_type()["id"] for cid in card_ids])
+    if not mw.col:
+        return []
+
+    card_ids: list[CardId] = mw.col.decks.cids(deck_id)
+    note_type_ids: set[NotetypeId] = set(
+        [mw.col.get_card(cid).note_type()["id"] for cid in card_ids]
+    )
     return list(note_type_ids)
 
 
-def get_note_ids(deck_id, note_type_id):
+def get_note_ids(deck_id: DeckId, note_type_id: NotetypeId) -> list[NoteId]:
     """Return a list of the IDs of notes, given a
     deck ID and note type ID.
     """
 
-    note_ids = []
+    if not mw.col:
+        return []
+
+    note_ids: list[NoteId] = []
     deck_card_ids = mw.col.decks.cids(deck_id)
     for cid in deck_card_ids:
         c = mw.col.get_card(cid)
@@ -201,7 +236,9 @@ def get_note_ids(deck_id, note_type_id):
     return note_ids
 
 
-def select_note_fields_add(note_type_id):
+def select_note_fields_add(
+    note_type_id: NotetypeId,
+) -> tuple[int, int, int] | tuple[None, None, None]:
     """For a given note type, prompt the user to select which field
     - contain the Japanese expression
     - contain the reading
@@ -210,7 +247,15 @@ def select_note_fields_add(note_type_id):
     type’s list of fields.
     """
 
-    choices = [nt["name"] for nt in mw.col.models.get(note_type_id)["flds"]]
+    if not (mw.col and mw.col.models):
+        return None, None, None
+
+    chosen_note_type: NotetypeDict | None = mw.col.models.get(note_type_id)
+
+    if not chosen_note_type:
+        return None, None, None
+
+    choices = [nt["name"] for nt in chosen_note_type["flds"]]
     expr_idx = customChooseList(
         "Which field contains the Japanese expression?", choices
     )
@@ -227,60 +272,73 @@ def select_note_fields_add(note_type_id):
     return expr_idx, reading_idx, output_idx
 
 
-def select_note_fields_del(note_type_id):
+def select_note_fields_del(note_type_id: NotetypeId) -> int | None:
     """For a given note type, prompt the user to select which field
     the pitch accent should be removed from, and return the respective
     index of this field in the note type’s list of fields.
     """
-    choices = [nt["name"] for nt in mw.col.models.get(note_type_id)["flds"]]
+
+    if not (mw.col and mw.col.models):
+        return None
+
+    chosen_note_type: NotetypeDict | None = mw.col.models.get(note_type_id)
+
+    if not chosen_note_type:
+        return None
+
+    choices = [nt["name"] for nt in chosen_note_type["flds"]]
     del_idx = customChooseList(
         "Which field should the pitch accent be removed from?", choices
     )
     return del_idx
 
 
-def remove_bracketed_content(dirty):
+def remove_bracketed_content(dirty: str) -> str:
     """Remove backets and their contents."""
 
     clean = re_bracketed_content_patt.sub("", dirty)
     return clean
 
 
-def remove_variation_selectors(dirty):
+def remove_variation_selectors(dirty: str) -> str:
     """Remove backets and their contents."""
 
     clean = re_variation_selectors_patt.sub("", dirty)
     return clean
 
 
-def clean_japanese_from_note_field(dirty):
+def clean_japanese_from_note_field(dirty: ExpressionStr) -> ExpressionStr | None:
     """Perform heuristic cleaning of an note field and return
     - the first consecutive string of Japanese if present
     - None otherwise
     """
 
     # heuristic cleaning
-    no_html = strip_html(dirty)
-    no_brack_html = remove_bracketed_content(no_html)
-    no_varsel_brack_html = remove_variation_selectors(no_brack_html)
+    no_html: str = strip_html(dirty)
+    no_brack_html: str = remove_bracketed_content(no_html)
+    no_varsel_brack_html: str = remove_variation_selectors(no_brack_html)
     # look for Japanese writing in expression field
     ja_match = re_ja_patt.search(no_varsel_brack_html)
     if ja_match:
         # return rist consecutive match
-        return ja_match.group(0)
+        return ExpressionStr(ja_match.group(0))
     # no Japanese text in field
     return None
 
 
-def get_acc_patt(expr_field, reading_field, dicts):
+def get_acc_patt(
+    expr_field: ExpressionStr, reading_field: HiraganaStr, dicts: list[AccentDict]
+) -> ReadingWithPitchPattern | None:
     """Determine the accept pattern for a note given its
     - expression field
     - reading field
     - accent pattern dictionaries to use for lookup
     """
 
-    def select_best_patt(reading_field, patts):
-        best_pos = 9001
+    def select_best_patt(
+        reading_field: HiraganaStr, patts: list[ReadingWithPitchPattern]
+    ) -> ReadingWithPitchPattern:
+        best_pos: int = 9001
         best = patts[0]  # default
         for patt in patts:
             hira, _ = patt
@@ -295,53 +353,66 @@ def get_acc_patt(expr_field, reading_field, dicts):
 
     expr_guess = clean_japanese_from_note_field(expr_field)
     if expr_guess is None:
-        return False
+        return None
     # look for hiragana in reading field
     hira_match = re_hira_patt.search(reading_field)
     if hira_match:
-        reading_guess = hira_match.group(0)
+        reading_guess = HiraganaStr(hira_match.group(0))
     else:
-        reading_guess = ""
+        reading_guess = HiraganaStr("")
     # dictionary lookup
     for dic in dicts:
-        patts = dic.get(expr_guess, False)
+        patts = dic.get(expr_guess, None)
         if patts:
             return select_best_patt(reading_guess, patts)
-    return False
+    return None
 
 
-def add_pitch(acc_dict, note_ids, expr_idx, reading_idx, output_idx):
+def add_pitch(
+    acc_dict: AccentDict,
+    note_ids: list[NoteId],
+    expr_idx: int,
+    reading_idx: int,
+    output_idx: int,
+):
     """Add pitch accent illustration to notes.
 
     Returns stats on how it went.
     """
 
-    not_found_list = []
-    num_updated = 0
-    num_already_done = 0
-    num_svg_fail = 0
+    not_found_list: list[tuple[NoteId, ExpressionStr]] = []
+    num_updated: int = 0
+    num_already_done: int = 0
+    num_svg_fail: int = 0
+
+    if not mw.col:
+        return not_found_list, num_updated, num_already_done, num_svg_fail
+
     for nid in note_ids:
         # set up note access
-        note = mw.col.get_note(nid)
-        expr_fld = note.keys()[expr_idx]
-        reading_fld = note.keys()[reading_idx]
-        output_fld = note.keys()[output_idx]
+        note: Note = mw.col.get_note(nid)
+        expr_fld: str = note.keys()[expr_idx]
+        reading_fld: str = note.keys()[reading_idx]
+        output_fld: str = note.keys()[output_idx]
         # check for existing illustrations
-        has_auto_accent = "<!-- accent_start -->" in note[output_fld]
-        has_manual_accent = "<!-- user_accent_start -->" in note[output_fld]
+        has_auto_accent: bool = "<!-- accent_start -->" in note[output_fld]
+        has_manual_accent: bool = "<!-- user_accent_start -->" in note[output_fld]
         if has_auto_accent or has_manual_accent:
             # already has a pitch accent illustration
             num_already_done += 1
             continue
         # determine accent pattern
-        expr_field = note[expr_fld].strip()
-        reading_field = note[reading_fld].strip()
-        patt = get_acc_patt(expr_field, reading_field, [acc_dict])
+        expr_field: ExpressionStr = ExpressionStr(note[expr_fld].strip())
+        reading_field: HiraganaStr = HiraganaStr(note[reading_fld].strip())
+        patt: ReadingWithPitchPattern | None = get_acc_patt(
+            expr_field, reading_field, [acc_dict]
+        )
         if not patt:
-            not_found_list.append([nid, expr_field])
+            not_found_list.append((nid, expr_field))
             continue
-        hira, LlHh_patt = patt
-        LH_patt = re.sub(r"[lh]", "", LlHh_patt)
+        hira: PitchAccentDisplayKana = patt[0]
+        LlHh_patt: PitchAccentNotationPerCharacter = patt[1]
+        LH_patt: PitchAccentNotationPerMora = char_lvl_patt_to_mora_lvl_patt(LlHh_patt)
         # generate SVG for accent pattern
         svg = pitch_svg(hira, LH_patt)
         if not svg:
@@ -379,6 +450,8 @@ def remove_pitch(note_ids, del_idx, user_set=False):
     )
     num_updated = 0
     num_already_done = 0
+    if not mw.col:
+        return num_already_done, num_updated
     for nid in note_ids:
         # set up note access
         note = mw.col.get_note(nid)
@@ -395,13 +468,15 @@ def remove_pitch(note_ids, del_idx, user_set=False):
     return num_already_done, num_updated
 
 
-def hira_to_kata(s):
+def hira_to_kata(s: HiraganaStr) -> KatakanaStr:
     """Convert hiragana to katakana."""
 
-    return "".join([chr(ord(ch) + 96) if ("ぁ" <= ch <= "ゔ") else ch for ch in s])
+    return KatakanaStr(
+        "".join([chr(ord(ch) + 96) if ("ぁ" <= ch <= "ゔ") else ch for ch in s])
+    )
 
 
-def is_katakana(s):
+def is_katakana(s: str) -> bool:
     """Determine if more than half of the characters in a
     string are katakana.
     """
@@ -413,7 +488,23 @@ def is_katakana(s):
     return num_ktkn / max(1, len(s)) > 0.5
 
 
-def clean_orth(orth):
+def char_lvl_patt_to_mora_lvl_patt(
+    c_patt: PitchAccentNotationPerCharacter,
+) -> PitchAccentNotationPerMora:
+    """Convert a character level pitch accent notation to a
+    mora level pitch accent notation, by removing all lower case
+    "l" and "h" characters.
+
+    Example:
+    旬（しゅん）
+    In : LlHH
+    Out: LHH
+    """
+
+    return PitchAccentNotationPerMora(re.sub(r"[lh]", "", c_patt))
+
+
+def clean_orth(orth: str) -> str:
     """Remove symbols from a string (used such that the remainder
     ideally is a clean word that can be looked up in the
     dictionary).

--- a/src/util.py
+++ b/src/util.py
@@ -10,12 +10,14 @@ from anki.cards import CardId
 from anki.notes import Note, NoteId
 from anki.models import NotetypeId, NotetypeDict
 from functools import lru_cache
+from typing import List
 from .draw_pitch import pitch_svg
 from .types import (
+    KanaStr,
     HiraganaStr,
-    KatakanaStr,
     ExpressionStr,
     PitchAccentDisplayKana,
+    PitchAccentNotation,
     PitchAccentNotationPerCharacter,
     PitchAccentNotationPerMora,
     ReadingWithPitchPattern,
@@ -153,21 +155,23 @@ def get_accent_dict(path: str | None = None) -> AccentDict:
         # load the default pitch accent dict
         path = os.path.join(get_plugin_dir_path(), "wadoku_pitchdb.csv")
 
-    acc_dict: dict[str, list[tuple[str, str]]] = {}
+    acc_dict: AccentDict = {}
     with open(path, encoding="utf8") as f:
         for line in f:
             line_parts = line.strip().split("\u241e")
-            orths_txt: ExpressionStr = ExpressionStr(line_parts[0])
-            hira: HiraganaStr = HiraganaStr(line_parts[1])
+            orths_txt: str = line_parts[0]
+            hira: KanaStr = KanaStr(line_parts[1])
             # hz = line_parts[2]
             # accs_txt = line_parts[3]
-            patts_txt: PitchAccentNotationPerCharacter = (
-                PitchAccentNotationPerCharacter(line_parts[4])
-            )
-            orth_txts = orths_txt.split("\u241f")
+            patts_txt: str = line_parts[4]
+            orth_txts: List[ExpressionStr] = [
+                ExpressionStr(s) for s in orths_txt.split("\u241f")
+            ]
             if clean_orth(orth_txts[0]) != orth_txts[0]:
                 orth_txts = [clean_orth(orth_txts[0])] + orth_txts
-            patts = patts_txt.split(",")
+            patts: List[PitchAccentNotationPerCharacter] = [
+                PitchAccentNotationPerCharacter(s) for s in patts_txt.split(",")
+            ]
             patt_common = patts[0]  # TODO: extend to support variants?
             if is_katakana(orth_txts[0]):
                 hira = hira_to_kata(hira)
@@ -193,10 +197,13 @@ def get_user_accent_dict(path: str | None = None) -> AccentDict:
         if not os.path.isfile(path):
             return {}
 
-    acc_dict: dict[str, list[tuple[str, str]]] = {}
+    acc_dict: AccentDict = {}
     with open(path, encoding="utf8") as f:
         for line in f:
-            orth, hira, patt = line.strip().split("\t")
+            line_parts = line.strip().split("\t")
+            orth: ExpressionStr = ExpressionStr(line_parts[0])
+            hira: KanaStr = KanaStr(line_parts[1])
+            patt: PitchAccentNotationPerMora = PitchAccentNotationPerMora(line_parts[2])
             if orth in acc_dict:
                 acc_dict[orth].append((hira, patt))
             else:
@@ -411,7 +418,7 @@ def add_pitch(
             not_found_list.append((nid, expr_field))
             continue
         hira: PitchAccentDisplayKana = patt[0]
-        LlHh_patt: PitchAccentNotationPerCharacter = patt[1]
+        LlHh_patt: PitchAccentNotation = patt[1]
         LH_patt: PitchAccentNotationPerMora = char_lvl_patt_to_mora_lvl_patt(LlHh_patt)
         # generate SVG for accent pattern
         svg = pitch_svg(hira, LH_patt)
@@ -468,10 +475,10 @@ def remove_pitch(note_ids, del_idx, user_set=False):
     return num_already_done, num_updated
 
 
-def hira_to_kata(s: HiraganaStr) -> KatakanaStr:
-    """Convert hiragana to katakana."""
+def hira_to_kata(s: KanaStr) -> KanaStr:
+    """Convert all hiragana in a string to katakana."""
 
-    return KatakanaStr(
+    return KanaStr(
         "".join([chr(ord(ch) + 96) if ("ぁ" <= ch <= "ゔ") else ch for ch in s])
     )
 
@@ -489,11 +496,12 @@ def is_katakana(s: str) -> bool:
 
 
 def char_lvl_patt_to_mora_lvl_patt(
-    c_patt: PitchAccentNotationPerCharacter,
+    c_patt: PitchAccentNotation,
 ) -> PitchAccentNotationPerMora:
     """Convert a character level pitch accent notation to a
     mora level pitch accent notation, by removing all lower case
-    "l" and "h" characters.
+    "l" and "h" characters. (If the input is already a mora level
+    pattern it is returned as is.)
 
     Example:
     旬（しゅん）
@@ -504,7 +512,7 @@ def char_lvl_patt_to_mora_lvl_patt(
     return PitchAccentNotationPerMora(re.sub(r"[lh]", "", c_patt))
 
 
-def clean_orth(orth: str) -> str:
+def clean_orth(orth: str) -> ExpressionStr:
     """Remove symbols from a string (used such that the remainder
     ideally is a clean word that can be looked up in the
     dictionary).
@@ -522,4 +530,4 @@ def clean_orth(orth: str) -> str:
     #  the moment anyway in case affix markers become relevant in
     #  the future)
     orth = orth.replace("…", "〜")
-    return orth
+    return ExpressionStr(orth)

--- a/src/util.py
+++ b/src/util.py
@@ -10,7 +10,6 @@ from anki.cards import CardId
 from anki.notes import Note, NoteId
 from anki.models import NotetypeId, NotetypeDict
 from functools import lru_cache
-from typing import List
 from .draw_pitch import pitch_svg
 from .types import (
     KanaStr,
@@ -164,12 +163,12 @@ def get_accent_dict(path: str | None = None) -> AccentDict:
             # hz = line_parts[2]
             # accs_txt = line_parts[3]
             patts_txt: str = line_parts[4]
-            orth_txts: List[ExpressionStr] = [
+            orth_txts: list[ExpressionStr] = [
                 ExpressionStr(s) for s in orths_txt.split("\u241f")
             ]
             if clean_orth(orth_txts[0]) != orth_txts[0]:
                 orth_txts = [clean_orth(orth_txts[0])] + orth_txts
-            patts: List[PitchAccentNotationPerCharacter] = [
+            patts: list[PitchAccentNotationPerCharacter] = [
                 PitchAccentNotationPerCharacter(s) for s in patts_txt.split(",")
             ]
             patt_common = patts[0]  # TODO: extend to support variants?

--- a/src/util.py
+++ b/src/util.py
@@ -1,29 +1,30 @@
-""" Utility functions.
-"""
+"""Utility functions."""
 
 import os
 import re
 from aqt import mw
-from aqt.utils import Qt, QDialog, QVBoxLayout, QLabel, QListWidget,\
-                      QDialogButtonBox
+from aqt.utils import Qt, QDialog, QVBoxLayout, QLabel, QListWidget, QDialogButtonBox
 from anki.utils import strip_html
 from functools import lru_cache
 from .draw_pitch import pitch_svg
-from ._constants import re_ja_patt, re_hira_patt, re_variation_selectors_patt,\
-                        re_bracketed_content_patt
+from ._constants import (
+    re_ja_patt,
+    re_hira_patt,
+    re_variation_selectors_patt,
+    re_bracketed_content_patt,
+)
 
 
 def get_qt_version():
-    """ Return the version of Qt used by Anki.
-    """
+    """Return the version of Qt used by Anki."""
 
     qt_ver = 5  # assume 5 for now
 
-    if Qt.__module__ == 'PyQt5.QtCore':
+    if Qt.__module__ == "PyQt5.QtCore":
         # PyQt5
         # tested on aqt[qt5]
         qt_ver = 5
-    elif Qt.__module__ == 'PyQt6.QtCore':
+    elif Qt.__module__ == "PyQt6.QtCore":
         # PyQt6
         # tested on aqt[qt6]
         qt_ver = 6
@@ -37,23 +38,22 @@ def get_qt_version():
 
 
 def get_plugin_dir_path():
-    """ Determine and return the path of the plugin directory.
-    """
+    """Determine and return the path of the plugin directory."""
 
     collection_path = mw.col.path
-    plugin_dir_name = __name__.split('.')[0]  # remove “.util”
+    plugin_dir_name = __name__.split(".")[0]  # remove “.util”
 
     user_dir_path = os.path.split(collection_path)[0]
     anki_dir_path = os.path.split(user_dir_path)[0]
-    plugin_dir_path = os.path.join(anki_dir_path, 'addons21', plugin_dir_name)
+    plugin_dir_path = os.path.join(anki_dir_path, "addons21", plugin_dir_name)
 
     return plugin_dir_path
 
 
 def customChooseList(msg, choices, startrow=0):
-    """ Copy of https://github.com/ankitects/anki/blob/main/
-        qt/aqt/utils.py but with a cancel button and title
-        parameter added.
+    """Copy of https://github.com/ankitects/anki/blob/main/
+    qt/aqt/utils.py but with a cancel button and title
+    parameter added.
     """
 
     parent = mw.app.activeWindow()
@@ -72,8 +72,9 @@ def customChooseList(msg, choices, startrow=0):
     c.setCurrentRow(startrow)
     l.addWidget(c)
     if get_qt_version() == 6:
-        buts = QDialogButtonBox.StandardButton.Ok | \
-               QDialogButtonBox.StandardButton.Cancel
+        buts = (
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
     else:
         buts = QDialogButtonBox.Ok | QDialogButtonBox.Cancel
     bb = QDialogButtonBox(buts)
@@ -91,41 +92,38 @@ def customChooseList(msg, choices, startrow=0):
 
 
 def select_deck_id(msg):
-    """ UI dialog that prints <msg> as a prompt to
-        the user shows a list of all decks in the
-        collection.
-        Returns the ID of the selected deck or None
-        if dialog is cancelled.
+    """UI dialog that prints <msg> as a prompt to
+    the user shows a list of all decks in the
+    collection.
+    Returns the ID of the selected deck or None
+    if dialog is cancelled.
     """
 
     decks = mw.col.decks.all()
-    choices = [d['name'] for d in decks]
+    choices = [d["name"] for d in decks]
     choice_idx = customChooseList(msg, choices)
     if choice_idx is None:
         return None
-    return decks[choice_idx]['id']
+    return decks[choice_idx]["id"]
 
 
 def select_note_type_id(note_type_ids):
-    """ UI dialog that prompts the user to select a
-        note type.
-        Returns the ID of the selected name type or
-        None if dialog is cancelled.
+    """UI dialog that prompts the user to select a
+    note type.
+    Returns the ID of the selected name type or
+    None if dialog is cancelled.
     """
 
     note_types = mw.col.models.all()
     choices = [
-        {'id': nt['id'], 'name': nt['name']}
+        {"id": nt["id"], "name": nt["name"]}
         for nt in note_types
-        if nt['id'] in note_type_ids
+        if nt["id"] in note_type_ids
     ]
-    choice_idx = customChooseList(
-        'Select a note type.',
-        [c['name'] for c in choices]
-    )
+    choice_idx = customChooseList("Select a note type.", [c["name"] for c in choices])
     if choice_idx is None:
         return None
-    return choices[choice_idx]['id']
+    return choices[choice_idx]["id"]
 
 
 @lru_cache(maxsize=1)
@@ -133,21 +131,16 @@ def get_accent_dict(path=None):
 
     if path is None:
         # load the default pitch accent dict
-        path = os.path.join(
-            get_plugin_dir_path(),
-            'wadoku_pitchdb.csv'
-        )
+        path = os.path.join(get_plugin_dir_path(), "wadoku_pitchdb.csv")
 
     acc_dict = {}
-    with open(path, encoding='utf8') as f:
+    with open(path, encoding="utf8") as f:
         for line in f:
-            orths_txt, hira, hz, accs_txt, patts_txt = line.strip().split(
-                '\u241e'
-            )
-            orth_txts = orths_txt.split('\u241f')
+            orths_txt, hira, hz, accs_txt, patts_txt = line.strip().split("\u241e")
+            orth_txts = orths_txt.split("\u241f")
             if clean_orth(orth_txts[0]) != orth_txts[0]:
                 orth_txts = [clean_orth(orth_txts[0])] + orth_txts
-            patts = patts_txt.split(',')
+            patts = patts_txt.split(",")
             patt_common = patts[0]  # TODO: extend to support variants?
             if is_katakana(orth_txts[0]):
                 hira = hira_to_kata(hira)
@@ -169,17 +162,14 @@ def get_user_accent_dict(path=None):
 
     if path is None:
         # load the user custom pitch accent dict
-        path = os.path.join(
-            get_plugin_dir_path(),
-            'user_pitchdb.csv'
-        )
+        path = os.path.join(get_plugin_dir_path(), "user_pitchdb.csv")
         if not os.path.isfile(path):
             return {}
 
     acc_dict = {}
-    with open(path, encoding='utf8') as f:
+    with open(path, encoding="utf8") as f:
         for line in f:
-            orth, hira, patt = line.strip().split('\t')
+            orth, hira, patt = line.strip().split("\t")
             if orth in acc_dict:
                 acc_dict[orth].append((hira, patt))
             else:
@@ -188,53 +178,49 @@ def get_user_accent_dict(path=None):
 
 
 def get_note_type_ids(deck_id):
-    """ Return a list of the IDs of note types used
-        in a deck.
+    """Return a list of the IDs of note types used
+    in a deck.
     """
 
     card_ids = mw.col.decks.cids(deck_id)
-    note_type_ids = set(
-        [mw.col.get_card(cid).note_type()['id'] for cid in card_ids]
-    )
+    note_type_ids = set([mw.col.get_card(cid).note_type()["id"] for cid in card_ids])
     return list(note_type_ids)
 
 
 def get_note_ids(deck_id, note_type_id):
-    """ Return a list of the IDs of notes, given a
-        deck ID and note type ID.
+    """Return a list of the IDs of notes, given a
+    deck ID and note type ID.
     """
 
     note_ids = []
     deck_card_ids = mw.col.decks.cids(deck_id)
     for cid in deck_card_ids:
         c = mw.col.get_card(cid)
-        if c.note_type()['id'] == note_type_id and c.nid not in note_ids:
+        if c.note_type()["id"] == note_type_id and c.nid not in note_ids:
             note_ids.append(c.nid)
     return note_ids
 
 
 def select_note_fields_add(note_type_id):
-    """ For a given note type, prompt the user to select which field
-        - contain the Japanese expression
-        - contain the reading
-        - the pitch accent should be shown in
-        and return the respective indices of those fields in the note
-        type’s list of fields.
+    """For a given note type, prompt the user to select which field
+    - contain the Japanese expression
+    - contain the reading
+    - the pitch accent should be shown in
+    and return the respective indices of those fields in the note
+    type’s list of fields.
     """
 
-    choices = [nt['name'] for nt in mw.col.models.get(note_type_id)['flds']]
+    choices = [nt["name"] for nt in mw.col.models.get(note_type_id)["flds"]]
     expr_idx = customChooseList(
-        'Which field contains the Japanese expression?', choices
+        "Which field contains the Japanese expression?", choices
     )
     if expr_idx is None:
         return None, None, None
-    reading_idx = customChooseList(
-        'Which field contains the reading?', choices
-    )
+    reading_idx = customChooseList("Which field contains the reading?", choices)
     if reading_idx is None:
         return None, None, None
     output_idx = customChooseList(
-        'Which field should the pitch accent be shown in?', choices
+        "Which field should the pitch accent be shown in?", choices
     )
     if output_idx is None:
         return None, None, None
@@ -242,37 +228,35 @@ def select_note_fields_add(note_type_id):
 
 
 def select_note_fields_del(note_type_id):
-    """ For a given note type, prompt the user to select which field
-        the pitch accent should be removed from, and return the respective
-        index of this field in the note type’s list of fields.
+    """For a given note type, prompt the user to select which field
+    the pitch accent should be removed from, and return the respective
+    index of this field in the note type’s list of fields.
     """
-    choices = [nt['name'] for nt in mw.col.models.get(note_type_id)['flds']]
+    choices = [nt["name"] for nt in mw.col.models.get(note_type_id)["flds"]]
     del_idx = customChooseList(
-        'Which field should the pitch accent be removed from?', choices
+        "Which field should the pitch accent be removed from?", choices
     )
     return del_idx
 
 
 def remove_bracketed_content(dirty):
-    """ Remove backets and their contents.
-    """
+    """Remove backets and their contents."""
 
-    clean = re_bracketed_content_patt.sub('', dirty)
+    clean = re_bracketed_content_patt.sub("", dirty)
     return clean
 
 
 def remove_variation_selectors(dirty):
-    """ Remove backets and their contents.
-    """
+    """Remove backets and their contents."""
 
-    clean = re_variation_selectors_patt.sub('', dirty)
+    clean = re_variation_selectors_patt.sub("", dirty)
     return clean
 
 
 def clean_japanese_from_note_field(dirty):
-    """ Perform heuristic cleaning of an note field and return
-        - the first consecutive string of Japanese if present
-        - None otherwise
+    """Perform heuristic cleaning of an note field and return
+    - the first consecutive string of Japanese if present
+    - None otherwise
     """
 
     # heuristic cleaning
@@ -289,10 +273,10 @@ def clean_japanese_from_note_field(dirty):
 
 
 def get_acc_patt(expr_field, reading_field, dicts):
-    """ Determine the accept pattern for a note given its
-        - expression field
-        - reading field
-        - accent pattern dictionaries to use for lookup
+    """Determine the accept pattern for a note given its
+    - expression field
+    - reading field
+    - accent pattern dictionaries to use for lookup
     """
 
     def select_best_patt(reading_field, patts):
@@ -308,6 +292,7 @@ def get_acc_patt(expr_field, reading_field, dicts):
             except ValueError:
                 continue
         return best
+
     expr_guess = clean_japanese_from_note_field(expr_field)
     if expr_guess is None:
         return False
@@ -316,7 +301,7 @@ def get_acc_patt(expr_field, reading_field, dicts):
     if hira_match:
         reading_guess = hira_match.group(0)
     else:
-        reading_guess = ''
+        reading_guess = ""
     # dictionary lookup
     for dic in dicts:
         patts = dic.get(expr_guess, False)
@@ -326,9 +311,9 @@ def get_acc_patt(expr_field, reading_field, dicts):
 
 
 def add_pitch(acc_dict, note_ids, expr_idx, reading_idx, output_idx):
-    """ Add pitch accent illustration to notes.
+    """Add pitch accent illustration to notes.
 
-        Returns stats on how it went.
+    Returns stats on how it went.
     """
 
     not_found_list = []
@@ -342,8 +327,8 @@ def add_pitch(acc_dict, note_ids, expr_idx, reading_idx, output_idx):
         reading_fld = note.keys()[reading_idx]
         output_fld = note.keys()[output_idx]
         # check for existing illustrations
-        has_auto_accent = '<!-- accent_start -->' in note[output_fld]
-        has_manual_accent = '<!-- user_accent_start -->' in note[output_fld]
+        has_auto_accent = "<!-- accent_start -->" in note[output_fld]
+        has_manual_accent = "<!-- user_accent_start -->" in note[output_fld]
         if has_auto_accent or has_manual_accent:
             # already has a pitch accent illustration
             num_already_done += 1
@@ -356,41 +341,41 @@ def add_pitch(acc_dict, note_ids, expr_idx, reading_idx, output_idx):
             not_found_list.append([nid, expr_field])
             continue
         hira, LlHh_patt = patt
-        LH_patt = re.sub(r'[lh]', '', LlHh_patt)
+        LH_patt = re.sub(r"[lh]", "", LlHh_patt)
         # generate SVG for accent pattern
         svg = pitch_svg(hira, LH_patt)
         if not svg:
             num_svg_fail += 1
             continue
         if len(note[output_fld]) > 0:
-            separator = '<br><hr><br>'
+            separator = "<br><hr><br>"
         else:
-            separator = ''
+            separator = ""
         # extend and save note
-        note[output_fld] = (
-            '{}<!-- accent_start -->{}{}<!-- accent_end -->'
-            ).format(note[output_fld], separator, svg)  # add svg
+        note[output_fld] = ("{}<!-- accent_start -->{}{}<!-- accent_end -->").format(
+            note[output_fld], separator, svg
+        )  # add svg
         mw.col.update_note(note)
         num_updated += 1
     return not_found_list, num_updated, num_already_done, num_svg_fail
 
 
 def remove_pitch(note_ids, del_idx, user_set=False):
-    """ Remove pitch accent illustrations from a specified field.
+    """Remove pitch accent illustrations from a specified field.
 
-        Returns stats on how that went.
+    Returns stats on how that went.
     """
 
     # determine accent pattern to search for
     if user_set:
-        tag_prefix = 'user_'
+        tag_prefix = "user_"
     else:
-        tag_prefix = ''
+        tag_prefix = ""
     acc_patt = re.compile(
-        r'<!-- {}accent_start -->.+<!-- {}accent_end -->'.format(
+        r"<!-- {}accent_start -->.+<!-- {}accent_end -->".format(
             tag_prefix, tag_prefix
         ),
-        re.S
+        re.S,
     )
     num_updated = 0
     num_already_done = 0
@@ -399,47 +384,44 @@ def remove_pitch(note_ids, del_idx, user_set=False):
         note = mw.col.get_note(nid)
         del_fld = note.keys()[del_idx]
         # check for cards w/o accent illustrations
-        if ' {}accent_start'.format(tag_prefix) not in note[del_fld]:
+        if " {}accent_start".format(tag_prefix) not in note[del_fld]:
             # has no pitch accent illustration
             num_already_done += 1
             continue
         # update and save note
-        note[del_fld] = re.sub(acc_patt, '', note[del_fld])
+        note[del_fld] = re.sub(acc_patt, "", note[del_fld])
         mw.col.update_note(note)
         num_updated += 1
     return num_already_done, num_updated
 
 
 def hira_to_kata(s):
-    """ Convert hiragana to katakana.
-    """
+    """Convert hiragana to katakana."""
 
-    return ''.join(
-        [chr(ord(ch) + 96) if ('ぁ' <= ch <= 'ゔ') else ch for ch in s]
-        )
+    return "".join([chr(ord(ch) + 96) if ("ぁ" <= ch <= "ゔ") else ch for ch in s])
 
 
 def is_katakana(s):
-    """ Determine if more than half of the characters in a
-        string are katakana.
+    """Determine if more than half of the characters in a
+    string are katakana.
     """
 
     num_ktkn = 0
     for ch in s:
-        if ch == 'ー' or ('ァ' <= ch <= 'ヴ'):
+        if ch == "ー" or ("ァ" <= ch <= "ヴ"):
             num_ktkn += 1
-    return num_ktkn / max(1, len(s)) > .5
+    return num_ktkn / max(1, len(s)) > 0.5
 
 
 def clean_orth(orth):
-    """ Remove symbols from a string (used such that the remainder
-        ideally is a clean word that can be looked up in the
-        dictionary).
+    """Remove symbols from a string (used such that the remainder
+    ideally is a clean word that can be looked up in the
+    dictionary).
     """
 
     # remove characters used in Wadoku orthography notation
     # that likely won't appear on Anki cards
-    orth = re.sub('[()△×･〈〉{}]', '', orth)
+    orth = re.sub("[()△×･〈〉{}]", "", orth)
     # change affix indicator from ellipsis (as used in Wadoku)
     # to wave dash (as used by the author in Anki)
     # (NOTE: the current preprocessing used for Japanese expressions
@@ -448,5 +430,5 @@ def clean_orth(orth):
     #  the replacement below does have no effect. Keeping it in for
     #  the moment anyway in case affix markers become relevant in
     #  the future)
-    orth = orth.replace('…', '〜')
+    orth = orth.replace("…", "〜")
     return orth


### PR DESCRIPTION
Add type hints for better maintainability and make small fixes along the way. 

Checked ([@3ae2d00](https://github.com/IllDepence/anki_add_pitch_plugin/pull/54/changes/3ae2d007684e15607c0c6f4638d5cacb2cbc3933)) 
* [x] about dialog shows
* [x] bulk add works as expected
    * [x] note type has to be selected if there are multiple in a deck
    * [x] annotations are added
        * [x] selecting pitch based on reading works
        * [x] katakana switch works
        * [x] user dictionary works
        * [x] dividing line is added when field to annotate already has content
    * [x] notes with existing annotations are skipped
    * [x] notes with existing manual annotations are skipped
    * [x] cancelling works
* [x] bulk remove works as expected
    * [x] note type has to be selected if there are multiple in a deck
    * [x] annotations are removed
    * [x] notes with manual annotations are skipped
    * [x] cancelling works
* [x] manual add/edit/remove works as expected
* [x] remove all manually set works as expected
* [x] show custom DB path shows correct path
* [x] about dialog shows and links work