### PR TITLE
Make separator CSS styleable (i.e. also hideable)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -35,6 +35,7 @@ from .util import (
     select_note_fields_del,
     get_plugin_dir_path,
     get_acc_patt,
+    add_pitch_to_field_content,
     clean_japanese_from_note_field,
 )
 from .draw_pitch import pitch_svg
@@ -307,14 +308,8 @@ def set_pitch(editor, hira, LH_patt):
 
     # generate SVG
     svg = pitch_svg(hira, LH_patt)
-    if len(old_field_val_clean) > 0:
-        separator = "<br><hr><br>"
-    else:
-        separator = ""
-    new_field_val = (
-        f"{old_field_val_clean}"
-        f"<!-- user_accent_start -->{separator}{svg}<!-- user_accent_end -->"
-    )
+    # add pitch to field
+    new_field_val = add_pitch_to_field_content(old_field_val_clean, svg, True)
     if hira == "" and LH_patt == "":
         new_field_val = old_field_val_clean
 

--- a/src/util.py
+++ b/src/util.py
@@ -387,7 +387,8 @@ def add_pitch_to_field_content(
     Skipping or prior removal must be implemented in the calling method."""
 
     if len(field_content) > 0:
-        separator = '<span class="pitch_separator"><br><hr><br></span>'
+        sep_cls = 'class="pitch_separator"'
+        separator = f"<br {sep_cls}><hr {sep_cls}><br {sep_cls}>"
     else:
         separator = ""
 

--- a/src/util.py
+++ b/src/util.py
@@ -21,6 +21,7 @@ from .types import (
     PitchAccentNotationPerMora,
     ReadingWithPitchPattern,
     AccentDict,
+    SvgStr,
 )
 from ._constants import (
     re_ja_patt,
@@ -374,6 +375,35 @@ def get_acc_patt(
     return None
 
 
+def add_pitch_to_field_content(
+    field_content: str, pitch_svg: SvgStr, user_set: bool
+) -> str:
+    """Combines the existing field_content with the pitch_svg and returns the result.
+
+    To enable automated removal, pitch_svg is surrounded with HTML comment markers.
+    If field_content is non-empty, a separator is added inbetween it and the pitch annotation.
+
+    This function assumes there are no existing pitch annotations in field_content.
+    Skipping or prior removal must be implemented in the calling method."""
+
+    if len(field_content) > 0:
+        separator = '<span class="pitch_separator"><br><hr><br></span>'
+    else:
+        separator = ""
+
+    if user_set:
+        tag_prefix = "user_"
+    else:
+        tag_prefix = ""
+
+    return (
+        f"{field_content}"
+        f"<!-- {tag_prefix}accent_start -->"
+        f"{separator}{pitch_svg}"
+        f"<!-- {tag_prefix}accent_end -->"
+    )
+
+
 def add_pitch(
     acc_dict: AccentDict,
     note_ids: list[NoteId],
@@ -421,18 +451,8 @@ def add_pitch(
         LH_patt: PitchAccentNotationPerMora = char_lvl_patt_to_mora_lvl_patt(LlHh_patt)
         # generate SVG for accent pattern
         svg = pitch_svg(hira, LH_patt)
-        if not svg:
-            num_svg_fail += 1
-            continue
-        if len(note[output_fld]) > 0:
-            separator = "<br><hr><br>"
-        else:
-            separator = ""
         # extend and save note
-        note[output_fld] = (
-            f"{note[output_fld]}"
-            f"<!-- accent_start -->{separator}{svg}<!-- accent_end -->"
-        )
+        note[output_fld] = add_pitch_to_field_content(note[output_fld], svg, False)
         mw.col.update_note(note)
         num_updated += 1
     return not_found_list, num_updated, num_already_done, num_svg_fail


### PR DESCRIPTION
adding classes to separator tags (`<br><hr><br>`)

coming to think of it, the separator was already stylable using CSS pseudo classes like :last-of-kind.
but this makes it more straight forward